### PR TITLE
Add `SKIP_PREPACK` environment variable to publish actions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
         uses: MetaMask/action-npm-publish@v1.1.0
+        env:
+          SKIP_PREPACK: true
 
   publish-npm:
     environment: npm-publish
@@ -84,3 +86,5 @@ jobs:
           # This `NPM_TOKEN` needs to be manually set per-repository.
           # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.
           npm-token: ${{ secrets.NPM_TOKEN }}
+        env:
+          SKIP_PREPACK: true


### PR DESCRIPTION
This adds the missing `SKIP_PREPACK` environment variable to the publish actions, to avoid running scripts.