### PR TITLE
Add better validation of number type and value

### DIFF
--- a/src/parsers/__fixtures__/index.ts
+++ b/src/parsers/__fixtures__/index.ts
@@ -1,0 +1,1 @@
+export * from './number';

--- a/src/parsers/__fixtures__/number.ts
+++ b/src/parsers/__fixtures__/number.ts
@@ -1,0 +1,190 @@
+export const NUMBER_VECTORS = [
+  {
+    type: 'uint8',
+    value: BigInt('0'),
+    hex: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  },
+  {
+    type: 'uint8',
+    value: BigInt('1'),
+    hex: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  },
+  {
+    type: 'uint8',
+    value: BigInt('255'),
+    hex: '0x00000000000000000000000000000000000000000000000000000000000000ff',
+  },
+  {
+    type: 'uint16',
+    value: BigInt('65535'),
+    hex: '0x000000000000000000000000000000000000000000000000000000000000ffff',
+  },
+  {
+    type: 'uint32',
+    value: BigInt('4294967295'),
+    hex: '0x00000000000000000000000000000000000000000000000000000000ffffffff',
+  },
+  {
+    type: 'uint64',
+    value: BigInt('18446744073709551615'),
+    hex: '0x000000000000000000000000000000000000000000000000ffffffffffffffff',
+  },
+  {
+    type: 'uint128',
+    value: BigInt('340282366920938463463374607431768211455'),
+    hex: '0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff',
+  },
+  {
+    type: 'uint256',
+    value: BigInt(
+      '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+    ),
+    hex: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+  },
+  {
+    type: 'int8',
+    value: BigInt('-128'),
+    hex: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80',
+  },
+  {
+    type: 'int8',
+    value: BigInt('127'),
+    hex: '0x000000000000000000000000000000000000000000000000000000000000007f',
+  },
+  {
+    type: 'int16',
+    value: BigInt('-32768'),
+    hex: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8000',
+  },
+  {
+    type: 'int16',
+    value: BigInt('32767'),
+    hex: '0x0000000000000000000000000000000000000000000000000000000000007fff',
+  },
+  {
+    type: 'int32',
+    value: BigInt('-2147483648'),
+    hex: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff80000000',
+  },
+  {
+    type: 'int32',
+    value: BigInt('2147483647'),
+    hex: '0x000000000000000000000000000000000000000000000000000000007fffffff',
+  },
+  {
+    type: 'int64',
+    value: BigInt('-9223372036854775808'),
+    hex: '0xffffffffffffffffffffffffffffffffffffffffffffffff8000000000000000',
+  },
+  {
+    type: 'int64',
+    value: BigInt('9223372036854775807'),
+    hex: '0x0000000000000000000000000000000000000000000000007fffffffffffffff',
+  },
+  {
+    type: 'int128',
+    value: BigInt('-170141183460469231731687303715884105728'),
+    hex: '0xffffffffffffffffffffffffffffffff80000000000000000000000000000000',
+  },
+  {
+    type: 'int128',
+    value: BigInt('170141183460469231731687303715884105727'),
+    hex: '0x000000000000000000000000000000007fffffffffffffffffffffffffffffff',
+  },
+  {
+    type: 'int256',
+    value: BigInt(
+      '-57896044618658097711785492504343953926634992332820282019728792003956564819968',
+    ),
+    hex: '0x8000000000000000000000000000000000000000000000000000000000000000',
+  },
+  {
+    type: 'int256',
+    value: BigInt(
+      '57896044618658097711785492504343953926634992332820282019728792003956564819967',
+    ),
+    hex: '0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+  },
+];
+
+export const DECODE_OUT_OF_RANGE_NUMBER_VECTORS = [
+  {
+    type: 'uint8',
+    hex: '0x0000000000000000000000000000000000000000000000000000000000000100',
+  },
+  {
+    type: 'uint16',
+    hex: '0x0000000000000000000000000000000000000000000000000000000000010000',
+  },
+  {
+    type: 'uint32',
+    hex: '0x0000000000000000000000000000000000000000000000000000000100000000',
+  },
+  {
+    type: 'uint64',
+    hex: '0x0000000000000000000000000000000000000000000000010000000000000000',
+  },
+  {
+    type: 'uint128',
+    hex: '0x0000000000000000000000000000000100000000000000000000000000000000',
+  },
+  {
+    type: 'int8',
+    hex: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f',
+  },
+  {
+    type: 'int16',
+    hex: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fff',
+  },
+  {
+    type: 'int32',
+    hex: '0xffffffffffffffffffffffffffffffffffffffffffffffff7fffffff00000000',
+  },
+  {
+    type: 'int64',
+    hex: '0xffffffffffffffffffffffffffffffffffffffff7fffffffffffffff00000000',
+  },
+  {
+    type: 'int128',
+    hex: '0xffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffff',
+  },
+];
+
+// Values that are out of range for the given type.
+export const OUT_OF_RANGE_NUMBER_VECTORS = [
+  {
+    type: 'uint256',
+    value: BigInt(2) ** BigInt(256),
+  },
+  {
+    type: 'uint8',
+    value: BigInt(2) ** BigInt(8),
+  },
+  {
+    type: 'int256',
+    value: BigInt(2) ** BigInt(255),
+  },
+  {
+    type: 'int256',
+    value: BigInt(2) ** BigInt(255) * BigInt(-1) - BigInt(1),
+  },
+  {
+    type: 'int8',
+    value: BigInt(2) ** BigInt(7),
+  },
+  {
+    type: 'int8',
+    value: BigInt(-2) ** BigInt(7) - BigInt(1),
+  },
+];
+
+export const INVALID_NUMBER_TYPE_VECTORS = [
+  '',
+  'unt',
+  'iunt',
+  'array',
+  'bytes',
+  'string',
+  'bool',
+  'address',
+];

--- a/src/parsers/number.ts
+++ b/src/parsers/number.ts
@@ -81,7 +81,7 @@ export const assertNumberLength = (value: bigint, type: string) => {
     // `2^(length - 1) - 1`.
     assert(
       value >= -(maxValue + BigInt(1)) && value <= maxValue,
-      `Number "${value}" is out of range for type "${type}".`,
+      new ParserError(`Number "${value}" is out of range for type "${type}".`),
     );
 
     return;
@@ -90,7 +90,7 @@ export const assertNumberLength = (value: bigint, type: string) => {
   // Unsigned types must be in the range of `0` to `2^length - 1`.
   assert(
     value <= maxValue,
-    `Number "${value}" is out of range for type "${type}".`,
+    new ParserError(`Number "${value}" is out of range for type "${type}".`),
   );
 };
 

--- a/src/parsers/number.ts
+++ b/src/parsers/number.ts
@@ -1,4 +1,5 @@
 import {
+  assert,
   bigIntToBytes,
   bytesToBigInt,
   bytesToSignedBigInt,
@@ -11,7 +12,7 @@ import { padStart } from '../utils';
 import { ParserError } from '../errors';
 import { DecodeArgs, Parser } from './parser';
 
-const NUMBER_REGEX = /^u?int([0-9]*)?$/u;
+const NUMBER_REGEX = /^u?int(?<length>[0-9]*)?$/u;
 
 /**
  * Check if a number type is signed.
@@ -21,6 +22,76 @@ const NUMBER_REGEX = /^u?int([0-9]*)?$/u;
  */
 export const isSigned = (type: string): boolean => {
   return !type.startsWith('u');
+};
+
+/**
+ * Get the length of the specified type. If a length is not specified, if the
+ * length is out of range (8 <= n <= 256), or if the length is not a multiple of
+ * 8, this will throw an error.
+ *
+ * @param type - The type to get the length for.
+ * @returns The bit length of the type.
+ */
+export const getLength = (type: string): number => {
+  if (type === 'int' || type === 'uint') {
+    return 256;
+  }
+
+  const match = type.match(NUMBER_REGEX);
+  assert(
+    match?.groups?.length,
+    new ParserError(
+      `Invalid number type. Expected a number type, but received "${type}".`,
+    ),
+  );
+
+  const length = parseInt(match.groups.length, 10);
+  assert(
+    length >= 8 && length <= 256,
+    new ParserError(
+      `Invalid number length. Expected a number between 8 and 256, but received "${type}".`,
+    ),
+  );
+
+  assert(
+    length % 8 === 0,
+    new ParserError(
+      `Invalid number length. Expected a multiple of 8, but received "${type}".`,
+    ),
+  );
+
+  return length;
+};
+
+/**
+ * Assert that the byte length of the given value is in range for the given
+ * number type.
+ *
+ * @param value - The value to check.
+ * @param type - The type of the value.
+ * @throws If the value is out of range for the type.
+ */
+export const assertNumberLength = (value: bigint, type: string) => {
+  const length = getLength(type);
+  const maxValue =
+    BigInt(2) ** BigInt(length - (isSigned(type) ? 1 : 0)) - BigInt(1);
+
+  if (isSigned(type)) {
+    // Signed types must be in the range of `-(2^(length - 1))` to
+    // `2^(length - 1) - 1`.
+    assert(
+      value >= -(maxValue + BigInt(1)) && value <= maxValue,
+      `Number "${value}" is out of range for type "${type}".`,
+    );
+
+    return;
+  }
+
+  // Unsigned types must be in the range of `0` to `2^length - 1`.
+  assert(
+    value <= maxValue,
+    `Number "${value}" is out of range for type "${type}".`,
+  );
 };
 
 /**
@@ -78,6 +149,9 @@ export const number: Parser<NumberLike, bigint> = {
    */
   encode({ type, buffer, value }): Uint8Array {
     const bigIntValue = getBigInt(value);
+
+    assertNumberLength(bigIntValue, type);
+
     if (isSigned(type)) {
       return concatBytes([
         buffer,
@@ -97,11 +171,15 @@ export const number: Parser<NumberLike, bigint> = {
    * @returns The decoded value.
    */
   decode({ type, value }: DecodeArgs): bigint {
-    const buffer = value.slice(0, 32);
+    const buffer = value.subarray(0, 32);
     if (isSigned(type)) {
-      return bytesToSignedBigInt(buffer);
+      const numberValue = bytesToSignedBigInt(buffer);
+      assertNumberLength(numberValue, type);
+      return numberValue;
     }
 
-    return bytesToBigInt(buffer);
+    const numberValue = bytesToBigInt(buffer);
+    assertNumberLength(numberValue, type);
+    return numberValue;
   },
 };


### PR DESCRIPTION
Closes #10.

This adds better validation for number types (`(u)int(n)`) and their values.

- It will check if the type length is within the allowed bounds, i.e., `8 <= n <= 256`.
- It will check if the value to encode is within the byte length of the number type.
- It will check if the decoded value is within the byte length of the number type.

I've also added some more tests for the number parser.