### PR TITLE
Exclude `__fixtures__` folder from dist

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,5 +9,5 @@
     "sourceMap": true
   },
   "include": ["./src/**/*.ts"],
-  "exclude": ["./src/**/*.test.ts"]
+  "exclude": ["./src/**/*.test.ts", "./src/**/__fixtures__/**/*"]
 }


### PR DESCRIPTION
This is a small change to the build TypeScript config, to exclude the `__fixtures__` test folder from the `dist` folder.