### PR TITLE
Fix broken publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -100,7 +100,6 @@ jobs:
         run: ./scripts/get.sh ".version" "RELEASE_VERSION"
 
   publish-release-to-gh-pages:
-    runs-on: ubuntu-latest
     needs: get-release-version
     name: Publish docs to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
     permissions:
@@ -110,7 +109,6 @@ jobs:
       destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
 
   publish-release-to-latest-gh-pages:
-    runs-on: ubuntu-latest
     needs: publish-npm
     name: Publish docs to `latest` directory of `gh-pages` branch
     permissions:


### PR DESCRIPTION
The `publish-release.yml` workflow of `metamask-module-template` was broken on accident. This applies the latest changes.

MetaMask/metamask-module-template#124