### PR TITLE
deps: @metamask/utils@^5.0.2->^6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/utils": "^5.0.2",
+    "@metamask/utils": "^6.1.0",
     "superstruct": "^1.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,7 +972,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
-    "@metamask/utils": ^5.0.2
+    "@metamask/utils": ^6.1.0
     "@noble/hashes": ^1.1.3
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
@@ -1062,16 +1062,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "@metamask/utils@npm:5.0.2"
+"@metamask/utils@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@metamask/utils@npm:6.1.0"
   dependencies:
     "@ethereumjs/tx": ^4.1.2
     "@types/debug": ^4.1.7
     debug: ^4.3.4
     semver: ^7.3.8
     superstruct: ^1.0.3
-  checksum: eca82e42911b2840deb4f32f0f215c5ffd14d22d68afbbe92d3180e920e509e310777b15eab29def3448f3535b66596ceb4c23666ec846adacc8e1bb093ff882
+  checksum: d4eac3ce3c08674b8e9ef838d1661a5025690c6f266c26ebdb8e8d0da11fce786e54c326b5d9c6d33b262f37e7057e31d6545a3715613bd0a5bfa10e7755643a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Improvements and security fix.

[6.0 Release notes](https://github.com/MetaMask/utils/releases/tag/v6.0.0)

> BREAKING: Bump minimum Node version to 16 (https://github.com/MetaMask/utils/pull/102)
> BREAKING: Target ES2020 (https://github.com/MetaMask/utils/pull/102) 

These don't necessitate any changes in this library.