### PR TITLE
BREAKING: Drop support for Node.js 16

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -83,7 +83,7 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, null, DependencyType) :-
   DependencyType == 'devDependencies'.
 
 % The package must specify a minimum Node version of 16.
-gen_enforced_field(WorkspaceCwd, 'engines.node', '>=16.0.0').
+gen_enforced_field(WorkspaceCwd, 'engines.node', '^18.18 || ^20.14 || >=22').
 
 % The package is public.
 gen_enforced_field(WorkspaceCwd, 'publishConfig.access', 'public').

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "packageManager": "yarn@3.2.3",
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^18.18 || ^20.14 || >=22"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
This drops support for Node.js 16, which is EOL.