### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -12,7 +12,7 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -27,7 +27,7 @@ jobs:
         node-version: [22.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -49,7 +49,7 @@ jobs:
         node-version: [22.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -77,7 +77,7 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
@@ -99,7 +99,7 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: true
 
@@ -34,7 +34,7 @@ jobs:
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
 
-      - uses: MetaMask/action-create-release-pr@v4
+      - uses: MetaMask/action-create-release-pr@268f95dd4099efbf661dd8ad7a979e7c8cc61ff9 # v4.0.0
         with:
           release-type: ${{ github.event.inputs.release-type }}
           release-version: ${{ github.event.inputs.release-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: false
       - name: Download actionlint
@@ -77,7 +77,7 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-is-release@v1
+      - uses: MetaMask/action-is-release@ae1ebc864afddef847279b999952c7b8fbe21005 # v1.1.0
         id: is-release
 
   publish-release:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,7 +22,7 @@ jobs:
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: true
       - name: Run build script

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - uses: MetaMask/action-publish-release@v3
+      - uses: MetaMask/action-publish-release@f01f1be110d60fb07d86c880ce3d6bdb353524d3 # v3.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn build
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: publish-release-artifacts-${{ github.sha }}
           retention-days: 4
@@ -39,17 +39,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
       - name: Restore build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@7cd534ddf00d2a055c347f47fc831cc83795a73c # v5.3.1
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
@@ -62,16 +62,16 @@ jobs:
     environment: npm-publish
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
       - name: Restore build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@7cd534ddf00d2a055c347f47fc831cc83795a73c # v5.3.1
         with:
           # This `NPM_TOKEN` needs to be manually set per-repository.
           # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.
@@ -85,7 +85,7 @@ jobs:
     outputs:
       RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.sha }}
       - id: get-release-version

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -19,7 +19,7 @@ jobs:
       security-events: write
     steps:
       - name: Analyse code
-        uses: MetaMask/action-security-code-scanner@v1
+        uses: MetaMask/action-security-code-scanner@234d72bd10c689bdf09a58bcc96b367fb00f9ee8 # v1.1.0
         with:
           repo: ${{ github.repository }}
           paths_ignored: |


### PR DESCRIPTION
## Summary

Pin every `uses:` ref in `.github/workflows/` (and any composite action
files) to a full 40-character commit SHA, with the original tag
preserved as a `# vX` comment.

## Why

Tags and branches are mutable, so a compromised action can replace what
runs in our pipelines without changing the tag we reference. Pinning to
a SHA closes that supply-chain vector. See GitHub's hardening guide:
<https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions>.

## Deadline

**TechOps is enforcing SHA-pinned GitHub Actions across the org.**
Merging this PR brings the repo into compliance; workflows that still
reference mutable tags or branches may be blocked from running.

## How

Generated mechanically with [`pinact run`](https://github.com/suzuki-shunsuke/pinact).
No version bumps were applied (strict pin); follow-up upgrades can come
from Renovate or a separate `pinact run -u` PR.

## Test plan

- [ ] CI green on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical ref pinning with no version bumps or application code changes; CI behavior should match the previously referenced tags.
> 
> **Overview**
> Pins every third-party and MetaMask **`uses:`** reference under **`.github/workflows/`** from floating tags (e.g. `@v1`, `@v4`) to **40-character commit SHAs**, with the original version noted in a **`# vX`** comment. No workflow logic, inputs, or job structure changes—only how actions are resolved at runtime.
> 
> Coverage spans **build/lint/test**, **main** (including release detection), **create-release-pr**, **publish-release** (GitHub release, artifact upload/download, npm dry-run/publish, checkout), **publish-docs**, and **security-code-scanner**. Actions touched include **`MetaMask/action-checkout-and-setup`**, **`action-create-release-pr`**, **`action-is-release`**, **`action-publish-release`**, **`action-npm-publish`**, **`action-security-code-scanner`**, plus **`actions/upload-artifact`**, **`actions/download-artifact`**, and **`actions/checkout`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09c43ab8d6738ea5e426905b36588940a672ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->